### PR TITLE
added test 'should stop sending messages eventually after no more changes occur'

### DIFF
--- a/spec/crdt/peer_matrix_spec.rb
+++ b/spec/crdt/peer_matrix_spec.rb
@@ -118,4 +118,28 @@ RSpec.describe CRDT::PeerMatrix do
     expect(peer3.peer_matrix.causally_ready?(peer2.peer_id)).to be true
     expect(peer3.peer_matrix.causally_ready?(peer1.peer_id)).to be true
   end
+
+  it 'should stop sending messages eventually after no more changes occur' do
+    peer1, peer2 = CRDT::Peer.new, CRDT::Peer.new
+    peer1.ordered_list.insert(0, :a)
+
+    messages_terminate = false
+
+    for i in 0..5  # 5 rounds should more than sufficient for peers to get into a stable state
+      if !peer1.anything_to_send? && !peer2.anything_to_send?
+        messages_terminate = true
+        break
+      end
+
+      if peer1.anything_to_send?
+        peer2.process_message(peer1.make_message)
+      end
+
+      if peer1.anything_to_send?
+        peer1.process_message(peer2.make_message)
+      end
+    end
+
+    expect(messages_terminate).to be true
+  end
 end

--- a/spec/crdt/peer_matrix_spec.rb
+++ b/spec/crdt/peer_matrix_spec.rb
@@ -123,11 +123,8 @@ RSpec.describe CRDT::PeerMatrix do
     peer1, peer2 = CRDT::Peer.new, CRDT::Peer.new
     peer1.ordered_list.insert(0, :a)
 
-    messages_terminate = false
-
     for i in 0..5  # 5 rounds should more than sufficient for peers to get into a stable state
-      if !peer1.anything_to_send? && !peer2.anything_to_send?
-        messages_terminate = true
+      if not (peer1.anything_to_send? || peer2.anything_to_send?)
         break
       end
 
@@ -135,11 +132,11 @@ RSpec.describe CRDT::PeerMatrix do
         peer2.process_message(peer1.make_message)
       end
 
-      if peer1.anything_to_send?
+      if peer2.anything_to_send?
         peer1.process_message(peer2.make_message)
       end
     end
 
-    expect(messages_terminate).to be true
+    expect(peer1.anything_to_send? || peer2.anything_to_send?).to be false
   end
 end


### PR DESCRIPTION
There is a problem with clock updates. If a peer gets a clock update, it will increment its msg_count and send out another clock update to all peers. This will cause each of them to send out another clock update, and so on, infinitely. This is just a test case that tests for this.
